### PR TITLE
feature/111829437_kl

### DIFF
--- a/app/controllers/haikus_controller.rb
+++ b/app/controllers/haikus_controller.rb
@@ -14,6 +14,10 @@ class HaikusController < ApplicationController
     @haiku = Haiku.new(haiku_params)
     @haiku.lines.last.user = current_user
     if @haiku.save
+      if email_entered
+        invited = current_user.friend_by_email(email_entered)
+        UserMailer.invite_email(invited, current_user, @haiku).deliver_now
+      end
       redirect_to root_url, notice: "Haiku created!"
     else
       render "new"
@@ -24,5 +28,9 @@ class HaikusController < ApplicationController
 
   def haiku_params
     params.require(:haiku).permit(lines_attributes: [:content])
+  end
+
+  def email_entered
+    params.permit(:email)[:email]
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -55,10 +55,7 @@ class UsersController < ApplicationController
   end
 
   def add_friend
-    invited = User.find_or_create_by(email: email_entered) do |u|
-      u.password = u.password_confirmation = SecureRandom.base64(8)
-    end
-    current_user.friendships.find_or_create_by(friend: invited)
+    invited = current_user.friend_by_email(email_entered)
     redirect_to new_haiku_url
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,9 @@
+class UserMailer < ActionMailer::Base
+  default from: "from@example.com"
+
+  def invite_email(invited, user, haiku)
+    @user = user
+    @url = new_haiku_line_url(haiku, host: "haikus.example.com")
+    mail(to: invited.email, subject: "Come write Haiku")
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,4 +43,12 @@ class User < ActiveRecord::Base
   def forgot_password
     update(forgot_password_uuid: SecureRandom.uuid)
   end
+
+  def friend_by_email(email)
+    friend = self.class.find_or_create_by(email: email) do |u|
+      u.password = u.password_confirmation = SecureRandom.base64(8)
+    end
+    self.friendships.find_or_create_by(friend: friend)
+    friend
+  end
 end

--- a/app/views/haikus/new.html.erb
+++ b/app/views/haikus/new.html.erb
@@ -24,6 +24,7 @@
       <%= haiku_form.fields_for :lines do |line_form| %>
         <%= line_form.text_field :content, class: 'u-full-width' %>
       <% end %>
+      <%= text_field_tag :email %>
       <%= haiku_form.submit %>
     <% end %>
   </div>

--- a/app/views/user_mailer/invite_email.html.erb
+++ b/app/views/user_mailer/invite_email.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>haikus</h1>
+    <p>
+      Your friend <%= @user.email %> has invited you to write a haiku. <%= link_to "Click here", @url %> to write the next Haiku line!
+    </p>
+  </body>
+</html>

--- a/app/views/user_mailer/invite_email.text.erb
+++ b/app/views/user_mailer/invite_email.text.erb
@@ -1,0 +1,4 @@
+haikus
+===============================================
+
+Your friend <%= @user.email %> has invited you to write a haiku. <%= link_to "Click here", @url %> to write the next Haiku line!

--- a/spec/requests/haikus_spec.rb
+++ b/spec/requests/haikus_spec.rb
@@ -79,6 +79,14 @@ describe "haikus", type: :request do
         expect(Haiku.last.lines.first.user.email).to eq(user.email)
       end
 
+      it "should send an invite email" do
+        post '/sessions', params
+        expect {
+          post '/haikus', haiku: {"lines_attributes"=>{"0"=>{"content"=>"An afternoon breeze"}}},
+                          email: "test@example.com"
+        }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+
       it 'should not add a new haiku without line content' do
         post '/sessions', params
         expect(response.code).to eq('302')


### PR DESCRIPTION
Send "invited to write" email when haiku created, if email entered
https://www.pivotaltracker.com/story/show/111829437

Refactor `friend_by_email(email)` into User model 
+ add a user, if user of the email not found
+ add a friendship, if not established
+ return the befriended user