### PR TITLE
feature/112398353-kc

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -48,6 +48,9 @@ class UsersController < ApplicationController
       user.forgot_password
       flash[:notice] = "You will receive an email shortly, with instructions on how to reset your password"
       redirect_to root_path
+    elsif email_entered.blank?
+      flash[:error] = "Can't leave this blank."
+      redirect_to forgot_password_path
     else
       flash[:error] = "#{email_entered} is not associated with an account in our system. Enter a different email, or #{view_context.link_to('click here', sign_up_path)} to create an account.".html_safe
       redirect_to forgot_password_path

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -7,6 +7,7 @@ describe "user", type: :request do
   let(:new_params) {{ user: { email: new_user.email, password: new_user.password, password_confirmation: new_user.password} } }
   let(:login_params) { {email: login_user.email, password: login_user.password} }
   let(:forgot_password_params) {{ user: {email: existing_user.email }}}
+  let(:empty_forgot_password_params) {{ user: {email: '' }}}
   let(:invalid_email_forgot_password_params) {{ user: {email: 'wrong@g.com' }}}
 
   it "should render the html" do
@@ -39,6 +40,13 @@ describe "user", type: :request do
         patch '/enter_email', forgot_password_params
         expect(response.code).to eq("302")
         expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'left the email field blank' do
+      it 'redirects to the forgot password page' do
+        patch '/enter_email', empty_forgot_password_params
+        expect(response.code).to redirect_to(forgot_password_path)
       end
     end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/projects/1516637/stories/112398353

Add blank input error for forgot password field

If user inputs an empty field on forgot_password page,
he will see an error message saying "Can't leave this blank."