### PR TITLE
feature/111829455-kc

### DIFF
--- a/app/controllers/haikus_controller.rb
+++ b/app/controllers/haikus_controller.rb
@@ -1,5 +1,5 @@
 class HaikusController < ApplicationController
-  before_action :require_login, only: [:create]
+  before_action :require_login, only: [:create, :edit, :update]
 
   def index
     params[:scope_param] ||= "all"
@@ -28,10 +28,28 @@ class HaikusController < ApplicationController
     end
   end
 
+  def edit
+    @haiku = Haiku.find(params[:id])
+  end
+
+  def update
+    @haiku = Haiku.find(params[:id])
+    if @haiku.update(haiku_params)
+      flash[:notice] = "Your haiku is completed!"
+      redirect_to haiku_path(@haiku)
+    else
+      render :edit
+    end
+  end
+
+  def show
+    @haiku = Haiku.find(params[:id])
+  end
+
   private
 
   def haiku_params
-    params.require(:haiku).permit(lines_attributes: [:content])
+    params.require(:haiku).permit(lines_attributes: [:id, :content])
   end
 
   def email_entered

--- a/app/controllers/lines_controller.rb
+++ b/app/controllers/lines_controller.rb
@@ -17,9 +17,12 @@ class LinesController < ApplicationController
 
     @line = @haiku.lines.build(line_params)
     @line.user = current_user
-    if @line.save
+    if @line.save && @haiku.lines_count_valid?
       flash[:notice] = "Haiku line created!"
       redirect_to new_haiku_line_path(@haiku)
+    elsif !@haiku.lines_count_valid?
+      flash[:notice] = "You can edit your haiku before you complete it."
+      redirect_to edit_haiku_path(@haiku)
     else
       @count = @haiku.lines.count
       render 'new'

--- a/app/views/haikus/edit.html.erb
+++ b/app/views/haikus/edit.html.erb
@@ -1,0 +1,8 @@
+<h1>Haiku's Edit</h1>
+
+<%= form_for @haiku do |f| %>
+  <%= f.fields_for :lines do |builder| %>
+    <%= builder.text_field :content, class: 'u-full-width' %>
+  <% end %>
+  <%= f.submit "Submit", class: 'button-primary' %>
+<% end %>

--- a/app/views/haikus/show.html.erb
+++ b/app/views/haikus/show.html.erb
@@ -1,0 +1,5 @@
+<h1>Haiku's Show</h1>
+
+<% @haiku.lines.each do |line| %>
+  <li><%= line.content %></li>
+<% end %>

--- a/spec/factories/haikus.rb
+++ b/spec/factories/haikus.rb
@@ -12,5 +12,11 @@ FactoryGirl.define do
         create_list(:line, 2, haiku: haiku)
       end
     end
+
+    factory :haiku_with_line do
+      after(:create) do |haiku, evaluator|
+        create_list(:line, 1, haiku: haiku)
+      end
+    end
   end
 end

--- a/spec/requests/haikus_spec.rb
+++ b/spec/requests/haikus_spec.rb
@@ -174,4 +174,49 @@ describe "haikus", type: :request do
       end
     end
   end
+
+  let(:haiku_with_lines) { FactoryGirl.create(:haiku_with_lines) }
+  describe 'GET /haikus/edit' do
+    before do
+      post '/log_in', params
+    end
+
+    it "should render the edit form with haiku's lines in place" do
+      get "/haikus/#{haiku_with_lines.id}/edit"
+      expect(response).to have_http_status(200)
+      expect(response).to render_template('edit')
+      expect(response.body).to include(haiku_with_lines.lines.all.first.content)
+      expect(response.body).to include(haiku_with_lines.lines.all.second.content)
+      expect(response.body).to include(haiku_with_lines.lines.all.third.content)
+    end
+  end
+
+  describe 'PATCH /haikus' do
+    before do
+      post '/log_in', params
+    end
+
+    it "should update haiku with new line content" do
+      patch "/haikus/#{haiku_with_lines.id}", haiku: {"lines_attributes"=>{"0"=>{"content"=>"updated first line", "id"=>"1"},
+                                                                           "1"=>{"content"=>"updated second line", "id"=>"2"},
+                                                                           "2"=>{"content"=>"updated third line", "id"=>"3"}}}
+      expect(haiku_with_lines.lines.all.first.content).to eq("updated first line")
+      expect(haiku_with_lines.lines.all.second.content).to eq("updated second line")
+      expect(haiku_with_lines.lines.all.third.content).to eq("updated third line")
+      expect(response).to have_http_status(302)
+      expect(response).to redirect_to(haiku_path(haiku_with_lines))
+      expect(flash[:notice]).to eq("Your haiku is completed!")
+    end
+  end
+
+  describe 'GET /haikus/:id' do
+    it "should show completed haiku" do
+      get "/haikus/#{haiku_with_lines.id}"
+      expect(response).to have_http_status(200)
+      expect(response).to render_template('show')
+      expect(response.body).to include(haiku_with_lines.lines.all.first.content)
+      expect(response.body).to include(haiku_with_lines.lines.all.second.content)
+      expect(response.body).to include(haiku_with_lines.lines.all.third.content)
+    end
+  end
 end

--- a/spec/requests/lines_spec.rb
+++ b/spec/requests/lines_spec.rb
@@ -45,7 +45,16 @@ describe "lines", type: :request do
         expect(Line.last.user).not_to be_nil
       end
 
-      let!(:haiku_with_lines) { FactoryGirl.create(:haiku_with_lines) }
+      let(:haiku_with_line) { FactoryGirl.create(:haiku_with_line) }
+      it "should redirect to haiku edit template when adding third line" do
+        expect(haiku_with_line.lines.count).to eq(2)
+        post "/haikus/#{haiku_with_line.id}/lines", "line" => { "content" => "third line" }
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to(edit_haiku_path(haiku_with_line))
+        expect(flash[:notice]).to eq("You can edit your haiku before you complete it.")
+      end
+
+      let(:haiku_with_lines) { FactoryGirl.create(:haiku_with_lines) }
       it 'should not add more than 3 lines' do
         expect(haiku_with_lines.lines.count).to eq(3)
         expect(haiku_with_lines).to_not be_lines_count_valid


### PR DESCRIPTION
https://www.pivotaltracker.com/projects/1516637/stories/111829455

Complete Haiku functionality

After a user completes a haiku, 1) he should see his haiku in a form,
with all fields editable, and a message that says "You can edit your
haiku before you complete it". Allow that user to edit any line in that
haiku -- even a friend's line, if he wrote it with a friend. Supply a
button that says "Submit", and when the user clicks that button, save
the haiku, and show a flash message that says "Your haiku is completed!"