### PR TITLE
bugfix/115664489-tj

### DIFF
--- a/app/controllers/haikus_controller.rb
+++ b/app/controllers/haikus_controller.rb
@@ -17,7 +17,7 @@ class HaikusController < ApplicationController
     @haiku = Haiku.new(haiku_params)
     @haiku.lines.last.user = current_user
     if @haiku.save
-      if email_entered
+      if !email_entered.blank?
         invited = current_user.friend_by_email(email_entered)
         UserMailer.invite_email(invited, current_user, @haiku).deliver_now
       end

--- a/spec/requests/haikus_spec.rb
+++ b/spec/requests/haikus_spec.rb
@@ -107,11 +107,18 @@ describe "haikus", type: :request do
         expect(Haiku.last.lines.first.user.email).to eq(user.email)
       end
 
-      it "should send an invite email" do
+      it "should send an invite email if friend is invited" do
         expect {
           post '/haikus', haiku: {"lines_attributes"=>{"0"=>{"content"=>"An afternoon breeze"}}},
                           email: "test@example.com"
         }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+
+      it 'should not send an invite email if invited friend is blank' do
+        expect {
+          post '/haikus', haiku: {"lines_attributes"=>{"0"=>{"content"=>"An afternoon breeze"}}},
+                          email: ""
+        }.to change { ActionMailer::Base.deliveries.count }.by(0)
       end
 
       it 'should not add a new haiku without line content' do


### PR DESCRIPTION
- https://www.pivotaltracker.com/story/show/115664489
- fix SMTP error when friend field is blank during haiku creation